### PR TITLE
Add es6 module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    ["env", { "modules": false }]
+  ],
+  "env": {
+    "umd": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    }
+  }
+}

--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     ["env", { "modules": false }]
   ],
   "env": {
-    "umd": {
+    "cjs": {
       "plugins": ["transform-es2015-modules-commonjs"]
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.0.1",
   "description": "A function to test if an object is an immutable-js object",
   "main": "dist/index.js",
+  "module": "dist/es/index.js",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "./node_modules/.bin/babel src --out-dir dist --presets=es2015",
-    "test": "./node_modules/.bin/jasmine"
+    "build": "npm run build:umd && npm run build:es",
+    "build:umd": "BABEL_ENV=umd babel src --out-dir dist",
+    "build:es": "BABEL_ENV=es babel src --out-dir dist/es",
+    "test": "jasmine"
   },
   "repository": {
     "type": "git",
@@ -24,8 +27,8 @@
   },
   "homepage": "https://github.com/whawker/is-immutable#readme",
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
     "immutable": ">=3.0.0",
     "jasmine": "^2.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run build:umd && npm run build:es",
-    "build:umd": "BABEL_ENV=umd babel src --out-dir dist",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "BABEL_ENV=cjs babel src --out-dir dist",
     "build:es": "BABEL_ENV=es babel src --out-dir dist/es",
     "test": "jasmine"
   },


### PR DESCRIPTION
Saves very little space (100B) when consumed with webpack.

Also enables webpack 4 to concatenate it.